### PR TITLE
Clarify how to make it work on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is very early stages. All interfaces are subject to change. Supported platf
 
 ## Building
 
-Use the provided Makefile.
+Use the provided Makefile. You need Java 11 (not 17), Maven and Rustup (the error messages will prompt you to install that if you don't have it).
 
 Ensure tools are installed:
 
@@ -31,6 +31,8 @@ Install the maven packages locally:
 ```
 
 ## Using in Java
+
+Maven co-ordinates for the installed artifacts: `net.bluejekyll:wasmtime-java:1.0-SNAPSHOT`.
 
 ### Initializing the Wasmtime runtime
 

--- a/src/main/java/net/bluejekyll/wasmtime/Wasmtime.java
+++ b/src/main/java/net/bluejekyll/wasmtime/Wasmtime.java
@@ -35,6 +35,9 @@ public class Wasmtime {
         if (osName.contains("Mac OS X")) {
             osName = "Darwin";
         }
+        if (osArch.contains("amd64")) {
+            osArch = "x86_64";
+        }
 
         final String libName = System.mapLibraryName(NATIVE_LIB);
         final String libPath = String.format("NATIVE/%s/%s/%s", osName, osArch, libName);


### PR DESCRIPTION
The pre-requisites were not clear in the README, and the
Wasmtime bootstrapper makes a bad assumption about the 
location of the native library.